### PR TITLE
Adding template data

### DIFF
--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -48,7 +48,13 @@ function sendEmail(type, submission) {
         case 'submission':
             template = submissionTemplate
             data = {
-                title: submission.attributes.title
+                title: submission.attributes.title,
+                Sender_Name : "CVPRNAS 2023 Submissions",
+                Sender_Email : "submissions@nascompetition.com",
+                Sender_Address : "Newcastle University",
+                Sender_State : "Tyne and Wear",
+                Sender_Zip : "NE1 7RU",
+                Sender_Country : "United Kingdom"
             }
             break;
         case 'output':
@@ -73,7 +79,13 @@ function sendEmail(type, submission) {
             template = completedTemplate
             data = {
                 title: submission.attributes.title,
-                outputUrl: `${blockBlobClient.url}?${sasToken}`
+                outputUrl: `${blockBlobClient.url}?${sasToken}`,
+                Sender_Name : "CVPRNAS 2023 Submissions",
+                Sender_Email : "submissions@nascompetition.com",
+                Sender_Address : "Newcastle University",
+                Sender_State : "Tyne and Wear",
+                Sender_Zip : "NE1 7RU",
+                Sender_Country : "United Kingdom"
             }
         
             break;


### PR DESCRIPTION
## Description

Sender data is showing as blank in the email templates. 

Fixes # (issue) 

Issue not logged.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

In the SendGrid functionality, there is a build tool that allows you to add test data. Not possible to test the live email without making a change in the API code.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## What should reviewers look for?

Anything that might break the email functionality.


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
