### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ coverage
 ############################
 
 .env
-.env.example
+.env.*
 license.txt
 exports
 *.cache

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ APP_KEYS=
 SENTRY_DSN=           
 PUBLIC_URL=
 PUBLIC_ADMIN_URL=
-
-SLACK_WEBHOOK is in dvelopment
 `
+
+SLACK_WEBHOOK is in development, currently not functional.
 
 ### Running Locally
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Their code based entry is then uploaded to the same website which must then allo
 
 Between 5-10 submissions are expected per day during the allowed submission period. Competitors will ideally have email notification of their code status. It is expected that code will be uploaded in a zip format.
 
+A submission limit is set against each user, this should be zero at the beginning of the competition. A submission limit is set in the controllers/submision.js file. This can be updated as preferred and individual User limits can be changed (if necessary) through the Strapi admin content manager.
+
 
 ### Project Team
 Stephen McGough - ([stephen.mcgough@newcastle.ac.uk](mailto:stephen.mcgough@newcastle.ac.uk))

--- a/README.md
+++ b/README.md
@@ -44,20 +44,36 @@ Node.js, yarn
 
 Clone the repo into a suitable directory. Create an .env file containing the following variables:
 
-`JWT_SECRET
-API_TOKEN_SALT
-STORAGE_ACCOUNT_NAME
-STORAGE_ACCOUNT_KEY
-STORAGE_CONTAINER_NAME
-BATCH_ACCOUNT_NAME
-BATCH_ACCOUNT_KEY
-BATCH_ENDPOINT
-SLACK_WEBHOOK
+`
+ADMIN_JWT_SECRET=
+JWT_SECRET=
+API_TOKEN_SALT=
+STORAGE_ACCOUNT_NAME=
+STORAGE_ACCOUNT_KEY=
+STORAGE_CONTAINER_NAME=
+BATCH_ACCOUNT_NAME=
+BATCH_ACCOUNT_KEY=
+BATCH_ENDPOINT=
+SLACK_WEBHOOK=
+SENDGRID_API_KEY=
+DATABASE_PORT=
+DATABASE_SSL=
+DATABASE_NAME=
+DATABASE_USERNAME=
+DATABASE_PASSWORD=
+DATABASE_HOST=
+APP_KEYS=
+SENTRY_DSN=           
+PUBLIC_URL=
+PUBLIC_ADMIN_URL=
+
+SLACK_WEBHOOK is in dvelopment
 `
 
 ### Running Locally
 
-`yarn start` to start the Strapi admin application.
+`yarn start` to start the Strapi admin application. 
+`yarn develop` will put the app in development mode and allow the change of the Content-Type objects
 
 ## Deployment
 

--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -158,27 +158,27 @@ module.exports = createCoreController('api::submission.submission', ({strapi}) =
                 where: { email: user_email }
               })
 
-                user_entry.submissionCount = user_entry.submissionCount + 1
-       
-                // set submission limit
+            user_entry.submissionCount = user_entry.submissionCount + 1
+    
+            // set submission limit
 
-                if(user_entry.submissionCount <= 7) {
+            if(user_entry.submissionCount <= 7) {
 
-                    await strapi.query("plugin::users-permissions.user").update({
-                        where: { id: user_entry.id },
-                        data: {
-                            submissionCount: user_entry.submissionCount
-                        }
-                    }); 
+                await strapi.query("plugin::users-permissions.user").update({
+                    where: { id: user_entry.id },
+                    data: {
+                        submissionCount: user_entry.submissionCount
+                    }
+                }); 
 
-                    // Create DB Entry
-                    response = await super.create(ctx)           
-                }
-                else {
+                // Create DB Entry
+                response = await super.create(ctx)           
+            }
+            else {
 
-                    // TODO return error message to the user
-                    console.log('reached submission limit')  
-                }
+                // TODO return error message to the user
+                console.log('reached submission limit')  
+            }
             
         } catch (err) {
             console.error(err.message)

--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -144,36 +144,42 @@ module.exports = createCoreController('api::submission.submission', ({strapi}) =
             ctx.request.body.data.path = sasUrl
             ctx.request.body.data = JSON.stringify(ctx.request.body.data)
 
-            // Create DB Entry
-            response = await super.create(ctx)
+            // get user email
+            const form_data = JSON.parse(ctx.request.body.data)
+            const user_email = form_data["user_email"]
 
-
-            // Beginning of code to update the user submissionCount
-
-            /*
-
+        
             // update user submissionCount
-            console.log(`Updating user submission count ${submission}`)
+            console.log(`Updating user submission count`)
          
             // http://localhost:1337/api/users/1
 
-            const entry = await strapi.db.query('plugin::users-permissions.user').findOne({
-                where: { email: email }
+            const user_entry = await strapi.db.query('plugin::users-permissions.user').findOne({
+                where: { email: user_email }
               })
 
-              console.log(entry);
+                user_entry.submissionCount = user_entry.submissionCount + 1
+       
+             // set submission limit
 
-              
-             // http://localhost:1337/api/users/:id
+             if(user_entry.submissionCount <= 7) {
 
-            let updatedUser = await strapi.query("plugin::users-permissions.user").update({
-                where: { id: newUser.id },
-            }); 
-            
-            */
+                await strapi.query("plugin::users-permissions.user").update({
+                    where: { id: user_entry.id },
+                    data: {
+                        submissionCount: user_entry.submissionCount
+                    }
+                }); 
 
-            
+                // Create DB Entry
+                response = await super.create(ctx)
+                        
+             }
+             else {
 
+                // TODO return error message to the user
+                console.log('reached submission limit')  
+             }
             
         } catch (err) {
             console.error(err.message)

--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -147,9 +147,32 @@ module.exports = createCoreController('api::submission.submission', ({strapi}) =
             // Create DB Entry
             response = await super.create(ctx)
 
+
+            // Beginning of code to update the user submissionCount
+
+            /*
+
             // update user submissionCount
             console.log(`Updating user submission count ${submission}`)
-            await strapi.services.customServiceName.updateUser(user_id)
+         
+            // http://localhost:1337/api/users/1
+
+            const entry = await strapi.db.query('plugin::users-permissions.user').findOne({
+                where: { email: email }
+              })
+
+              console.log(entry);
+
+              
+             // http://localhost:1337/api/users/:id
+
+            let updatedUser = await strapi.query("plugin::users-permissions.user").update({
+                where: { id: newUser.id },
+            }); 
+            
+            */
+
+            
 
             
         } catch (err) {

--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -146,6 +146,11 @@ module.exports = createCoreController('api::submission.submission', ({strapi}) =
 
             // Create DB Entry
             response = await super.create(ctx)
+
+            // update user submissionCount
+            console.log(`Updating user submission count ${submission}`)
+            await strapi.services.customServiceName.updateUser(user_id)
+
             
         } catch (err) {
             console.error(err.message)

--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -160,26 +160,25 @@ module.exports = createCoreController('api::submission.submission', ({strapi}) =
 
                 user_entry.submissionCount = user_entry.submissionCount + 1
        
-             // set submission limit
+                // set submission limit
 
-             if(user_entry.submissionCount <= 7) {
+                if(user_entry.submissionCount <= 7) {
 
-                await strapi.query("plugin::users-permissions.user").update({
-                    where: { id: user_entry.id },
-                    data: {
-                        submissionCount: user_entry.submissionCount
-                    }
-                }); 
+                    await strapi.query("plugin::users-permissions.user").update({
+                        where: { id: user_entry.id },
+                        data: {
+                            submissionCount: user_entry.submissionCount
+                        }
+                    }); 
 
-                // Create DB Entry
-                response = await super.create(ctx)
-                        
-             }
-             else {
+                    // Create DB Entry
+                    response = await super.create(ctx)           
+                }
+                else {
 
-                // TODO return error message to the user
-                console.log('reached submission limit')  
-             }
+                    // TODO return error message to the user
+                    console.log('reached submission limit')  
+                }
             
         } catch (err) {
             console.error(err.message)

--- a/src/api/submission/controllers/user.js
+++ b/src/api/submission/controllers/user.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = createCoreController('api::user.user', ({strapi}) => ({
+
+    async find(ctx) {
+        const user = ctx.state.user;
+        ctx.query.filters = {
+          ...(ctx.query.filters || {}),
+          user: user.id,
+        };
+        return super.find(ctx);
+      },
+
+
+}));

--- a/src/api/submission/controllers/user.js
+++ b/src/api/submission/controllers/user.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = createCoreController('api::user.user', ({strapi}) => ({
+const { createCoreController } = require('@strapi/strapi').factories; 
+
+/*module.exports = createCoreController('api::user.user', ({strapi}) => ({
 
     async find(ctx) {
         const user = ctx.state.user;
@@ -12,4 +14,10 @@ module.exports = createCoreController('api::user.user', ({strapi}) => ({
       },
 
 
-}));
+})); */
+
+function updateUser(type, user) {
+
+  console.log(user.id);
+
+}

--- a/src/api/submission/services/user.js
+++ b/src/api/submission/services/user.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * user service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::user.id')

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-06-19T14:54:20.226Z"
+    "x-generation-date": "2023-06-19T15:49:43.585Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-06-26T14:51:08.973Z"
+    "x-generation-date": "2023-07-10T15:16:41.700Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-07-10T15:20:24.297Z"
+    "x-generation-date": "2023-07-10T15:21:40.502Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-06-19T14:42:39.876Z"
+    "x-generation-date": "2023-06-19T14:54:20.226Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-07-10T15:16:41.700Z"
+    "x-generation-date": "2023-07-10T15:20:24.297Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-06-19T15:49:43.585Z"
+    "x-generation-date": "2023-06-26T14:51:08.973Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-03-18T15:35:39.796Z"
+    "x-generation-date": "2023-06-19T14:42:39.876Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -28,7 +28,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8080/api",
+      "url": "http://localhost:1337/api",
       "description": "Development server"
     }
   ],
@@ -1424,6 +1424,9 @@
                                 }
                               }
                             }
+                          },
+                          "submissionCount": {
+                            "type": "integer"
                           },
                           "createdAt": {
                             "type": "string",
@@ -3428,6 +3431,9 @@
                                 }
                               }
                             }
+                          },
+                          "submissionCount": {
+                            "type": "integer"
                           },
                           "createdAt": {
                             "type": "string",
@@ -5466,6 +5472,9 @@
                               }
                             }
                           },
+                          "submissionCount": {
+                            "type": "integer"
+                          },
                           "createdAt": {
                             "type": "string",
                             "format": "date-time"
@@ -7469,6 +7478,9 @@
                                 }
                               }
                             }
+                          },
+                          "submissionCount": {
+                            "type": "integer"
                           },
                           "createdAt": {
                             "type": "string",
@@ -14576,6 +14588,9 @@
                                             }
                                           }
                                         },
+                                        "submissionCount": {
+                                          "type": "integer"
+                                        },
                                         "createdAt": {
                                           "type": "string",
                                           "format": "date-time"
@@ -15900,6 +15915,9 @@
                                               }
                                             }
                                           }
+                                        },
+                                        "submissionCount": {
+                                          "type": "integer"
                                         },
                                         "createdAt": {
                                           "type": "string",
@@ -17259,6 +17277,9 @@
                                             }
                                           }
                                         },
+                                        "submissionCount": {
+                                          "type": "integer"
+                                        },
                                         "createdAt": {
                                           "type": "string",
                                           "format": "date-time"
@@ -18583,6 +18604,9 @@
                                               }
                                             }
                                           }
+                                        },
+                                        "submissionCount": {
+                                          "type": "integer"
                                         },
                                         "createdAt": {
                                           "type": "string",
@@ -19931,6 +19955,9 @@
                                                             }
                                                           }
                                                         }
+                                                      },
+                                                      "submissionCount": {
+                                                        "type": "integer"
                                                       },
                                                       "createdAt": {
                                                         "type": "string",
@@ -21285,6 +21312,9 @@
                                                             }
                                                           }
                                                         }
+                                                      },
+                                                      "submissionCount": {
+                                                        "type": "integer"
                                                       },
                                                       "createdAt": {
                                                         "type": "string",
@@ -22673,6 +22703,9 @@
                                                           }
                                                         }
                                                       },
+                                                      "submissionCount": {
+                                                        "type": "integer"
+                                                      },
                                                       "createdAt": {
                                                         "type": "string",
                                                         "format": "date-time"
@@ -24027,6 +24060,9 @@
                                                           }
                                                         }
                                                       },
+                                                      "submissionCount": {
+                                                        "type": "integer"
+                                                      },
                                                       "createdAt": {
                                                         "type": "string",
                                                         "format": "date-time"
@@ -24313,6 +24349,9 @@
                   ],
                   "example": "string or id"
                 }
+              },
+              "submissionCount": {
+                "type": "integer"
               }
             }
           }
@@ -25519,6 +25558,9 @@
                                             }
                                           }
                                         },
+                                        "submissionCount": {
+                                          "type": "integer"
+                                        },
                                         "createdAt": {
                                           "type": "string",
                                           "format": "date-time"
@@ -25635,6 +25677,9 @@
                     }
                   }
                 }
+              },
+              "submissionCount": {
+                "type": "integer"
               },
               "createdAt": {
                 "type": "string",
@@ -26883,6 +26928,9 @@
                                             }
                                           }
                                         },
+                                        "submissionCount": {
+                                          "type": "integer"
+                                        },
                                         "createdAt": {
                                           "type": "string",
                                           "format": "date-time"
@@ -26999,6 +27047,9 @@
                     }
                   }
                 }
+              },
+              "submissionCount": {
+                "type": "integer"
               },
               "createdAt": {
                 "type": "string",
@@ -28280,6 +28331,9 @@
                                             }
                                           }
                                         },
+                                        "submissionCount": {
+                                          "type": "integer"
+                                        },
                                         "createdAt": {
                                           "type": "string",
                                           "format": "date-time"
@@ -28396,6 +28450,9 @@
                     }
                   }
                 }
+              },
+              "submissionCount": {
+                "type": "integer"
               },
               "createdAt": {
                 "type": "string",
@@ -29644,6 +29701,9 @@
                                             }
                                           }
                                         },
+                                        "submissionCount": {
+                                          "type": "integer"
+                                        },
                                         "createdAt": {
                                           "type": "string",
                                           "format": "date-time"
@@ -29760,6 +29820,9 @@
                     }
                   }
                 }
+              },
+              "submissionCount": {
+                "type": "integer"
               },
               "createdAt": {
                 "type": "string",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-07-10T15:21:40.502Z"
+    "x-generation-date": "2023-07-11T09:26:07.374Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -68,6 +68,9 @@
       "relation": "oneToMany",
       "target": "api::submission.submission",
       "mappedBy": "users_permissions_user"
+    },
+    "submissionCount": {
+      "type": "integer"
     }
   }
 }


### PR DESCRIPTION
## Description

Addition of a submission limit to the User content type. This will provide a back-up to client side checks on user submissions.

Fixes #22 

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

## How has this been tested?

This has been tested through Postman, with Strapi running locally but connected to the Azure database, rather than a local database. The below API was used with Bearer token authorisation. 

http://localhost:1337/api/submissions

(Console.log messages are generated to the terminal running Strapi, not the browser)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
