### PR TITLE
Update submission.js

### DIFF
--- a/src/api/submission/controllers/submission.js
+++ b/src/api/submission/controllers/submission.js
@@ -199,7 +199,7 @@ module.exports = createCoreController('api::submission.submission', ({strapi}) =
                 },
                 constraints: {
                     maxTaskRetryCount: 3,
-                    maxWallClockTime: 'P0Y0M0DT24H0M0S'
+                    maxWallClockTime: 'P0Y0M0DT1H0M0S'
                 },
                 outputFiles: [
                     {


### PR DESCRIPTION
Recuded lifetime to 1 hour

## Description

To prevent the VMs from overrunning for too long in case the submitted code gets caught in a unbreakable loop, I changed the maxWallClockTime to 1 hour.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.


<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
